### PR TITLE
Add option to disable individual messages through config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ New checks:
 * ``only-given-allowed-in-background``
 * ``tag-could-be-on-parent``
 
+Other changes:
+* Add support for configuration from a file. The file must be in `.toml` format.
+  You can include the configuration in your `pyproject.toml`, or if you don't use that,
+  you can create a `gherlint.toml` file in the root of your project.
+* Individual messages can now be disabled in the configuration file (section: reporting, option: disable).
+
 ## V0.4.0
 New checks:
 * ``unused-parameter``

--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ The following work items are planned for the upcoming releases:
     * Extend object model as necessary for checkers
     * Reach a stable interface for object model, checkers and reporters
     * Add documentation
-* V1.x - V2.0:
     * Support configuration to enable/disable individual messages
+* V1.x - V2.0:
     * Implement plugin architecture to allow users to add custom checkers

--- a/src/gherlint/reporting.py
+++ b/src/gherlint/reporting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass

--- a/src/gherlint/reporting.py
+++ b/src/gherlint/reporting.py
@@ -5,6 +5,7 @@ from typing import Dict
 
 from gherlint.exceptions import DuplicateMessageError, UnknownMessageError
 from gherlint.objectmodel.nodes import Document, Node
+from gherlint.options import Field, Options
 
 
 @dataclass(frozen=True)
@@ -62,8 +63,20 @@ class MessageStore:
             raise UnknownMessageError(f"Message name '{name}' not found.") from exc
 
 
+class ReporterOptions(Options):
+    config_section = "reporting"
+    disable: list[str] = Field(
+        default_factory=list, description="List of messages to disable."
+    )
+
+
 class Reporter(ABC):
     """Base class for reporters."""
+
+    options: ReporterOptions
+
+    def __init__(self):
+        self.options = ReporterOptions.from_config()
 
     def add_message(self, id_or_name: str, node: Node, **format_args) -> None:
         """Add a message, identified by its id or name, that shall be emitted"""
@@ -75,6 +88,9 @@ class Reporter(ABC):
             raise ValueError(
                 f"{id_or_name} matches neither the pattern for a message ID nor a message name."
             )
+        if message.id in self.options.disable or message.name in self.options.disable:
+            # Message is disabled
+            return
         self.emit(message, node, **format_args)
 
     @abstractmethod
@@ -89,6 +105,7 @@ class TextReporter(Reporter):
     MSG_TEMPLATE = "{file}:{line}:{column}: {text} ({name})"
 
     def __init__(self):
+        super().__init__()
         self.current_file = None
 
     def emit(self, message: Message, node: Node, **format_args) -> None:

--- a/src/gherlint/reporting.py
+++ b/src/gherlint/reporting.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, List
 
 from gherlint.exceptions import DuplicateMessageError, UnknownMessageError
 from gherlint.objectmodel.nodes import Document, Node
@@ -67,7 +65,7 @@ class MessageStore:
 
 class ReporterOptions(Options):
     config_section = "reporting"
-    disable: list[str] = Field(
+    disable: List[str] = Field(
         default_factory=list, description="List of messages to disable."
     )
 

--- a/tests/functional/misc/disabled_messages_in_config.feature
+++ b/tests/functional/misc/disabled_messages_in_config.feature
@@ -1,0 +1,12 @@
+Feature: Test
+
+    @wip
+    Scenario:
+        Given some precondition
+        When I do something
+        Then I expect some outcome
+
+    @wip
+    Scenario: Test
+        Given some precondition
+        When I do something

--- a/tests/functional/misc/disabled_messages_in_config.toml
+++ b/tests/functional/misc/disabled_messages_in_config.toml
@@ -1,0 +1,2 @@
+[reporting]
+disable = ["missing-scenario-name", "C103"]

--- a/tests/functional/misc/disabled_messages_in_config.txt
+++ b/tests/functional/misc/disabled_messages_in_config.txt
@@ -1,0 +1,5 @@
+************* disabled_messages_in_config.feature
+disabled_messages_in_config.feature:3:5: Common tags can be moved to the parent element (tag-could-be-on-parent)
+disabled_messages_in_config.feature:9:5: Common tags can be moved to the parent element (tag-could-be-on-parent)
+disabled_messages_in_config.feature:5:9: Consider putting common 'Given' steps in a Background (consider-using-background)
+disabled_messages_in_config.feature:11:9: Consider putting common 'Given' steps in a Background (consider-using-background)


### PR DESCRIPTION
Not all messages are useful for everyone.

This PR adds the possibility to globally disable specific messages through the configuration file. 