### PR TITLE
Update pyproject.toml for gherkin-official 24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ gherlint = 'gherlint.__main__:cli'
 
 [tool.poetry.dependencies]
 python = "^3.8"
-gherkin-official = "^22.0.0"
+gherkin-official = "^24.0.0"
 click = "^8.0.1"
 parse = "^1.19.0"
 tomli = "^1.0.0"


### PR DESCRIPTION
Just allows to use gherkin-official v24, current version makes it a conflict, notably if using reformat-gherkin